### PR TITLE
show real site name in all posts instead of mock name (folan.com)

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -26,11 +26,21 @@ class PostController extends Controller
         if (isset($request['page'])) {
             $page = $request['page'];
         }
+        
         $all_post_with_user = Post::where([])->orderBy('created_at', 'DESC')->with('user')->paginate(30);
+        
         $is_end = false;
         if ($all_post_with_user->lastPage() == $page) {
             $is_end = true;
         }
+
+        // find site name with regex and put it in $all_post_with_user 
+        $site_name_pattern = '/([a-zA-Z0-9]([a-zA-Z0-9\-]{0,65}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}/m';
+        foreach ($all_post_with_user as $post) {
+            preg_match_all($site_name_pattern, $post->link, $matches);
+            $post['site_name'] = $matches[0][0];
+        }
+
         return view('all_posts', [
             'posts' => $all_post_with_user,
             'page' => $request['page'],

--- a/resources/views/all_posts.blade.php
+++ b/resources/views/all_posts.blade.php
@@ -21,7 +21,7 @@
                         </span>
                         . {{ $post->title }}
                     </a>
-                    <span class="text-secondary link">(folan.com)</span>
+                    <span class="text-secondary link">({{ $post -> site_name }})</span>
                 </h2>
                 <h3 class="text-secondary">
                     {{ num_to_fa($post->likes - $post->dislikes)  }} 🔺 🔻 | نوشته {{ $post->user->name }} در


### PR DESCRIPTION
extract site name from each post's URL by using regular expression and add the site name to the same post inside `$all_post_with_user`, and show it in all_posts view instead of 'folan.com'.